### PR TITLE
Update MF7 recipe to latest changes in ENDF-102

### DIFF
--- a/endf_parserpy/endf_recipes/__init__.py
+++ b/endf_parserpy/endf_recipes/__init__.py
@@ -10,7 +10,7 @@ from .endf_recipe_mf3 import ENDF_RECIPE_MF3
 from .endf_recipe_mf4 import ENDF_RECIPE_MF4
 from .endf_recipe_mf5 import ENDF_RECIPE_MF5
 from .endf_recipe_mf6 import ENDF_RECIPE_MF6
-from .endf_recipe_mf7 import ENDF_RECIPE_MF7_MT2, ENDF_RECIPE_MF7_MT4
+from .endf_recipe_mf7 import ENDF_RECIPE_MF7_MT2, ENDF_RECIPE_MF7_MT4, ENDF_RECIPE_MF7_MT451
 from .endf_recipe_mf8 import ENDF_RECIPE_MF8
 from .endf_recipe_mf8_mt454 import ENDF_RECIPE_MF8_MT454
 from .endf_recipe_mf8_mt457 import ENDF_RECIPE_MF8_MT457
@@ -61,6 +61,7 @@ __defdic(endf_recipe_dictionary, (5,), ENDF_RECIPE_MF5)
 __defdic(endf_recipe_dictionary, (6,), ENDF_RECIPE_MF6)
 __defdic(endf_recipe_dictionary, (7, 2), ENDF_RECIPE_MF7_MT2)
 __defdic(endf_recipe_dictionary, (7, 4), ENDF_RECIPE_MF7_MT4)
+__defdic(endf_recipe_dictionary, (7, 451), ENDF_RECIPE_MF7_MT451)
 __defdic(endf_recipe_dictionary, (8, -1), ENDF_RECIPE_MF8)
 __defdic(endf_recipe_dictionary, (8, 454), ENDF_RECIPE_MF8_MT454)
 __defdic(endf_recipe_dictionary, (8, 457), ENDF_RECIPE_MF8_MT457)

--- a/endf_parserpy/endf_recipes/endf_recipe_mf7.py
+++ b/endf_parserpy/endf_recipes/endf_recipe_mf7.py
@@ -22,6 +22,13 @@ if LTHR==1:
 # Incoherent Elastic Scattering
 elif LTHR==2:
     [MAT, 7, 2/ SB, 0.0, 0, 0, NR, NP/ Tint / Wp ]TAB1
+elif LTHR==3:
+    [MAT, 7, 2/ T0, 0.0, LT, 0, NR, NP/ Eint / S ] TAB1 (S_T0_table)
+    for i=1 to LT:
+        [MAT, 7, 2/ T[i], 0.0, LI, 0, NP, 0/
+            {S[q,i]}{q=1 to NP} ] LIST
+    endfor
+    [MAT, 7, 2/ SB, 0.0, 0, 0, NR, NP/ Tint / Wp ]TAB1
 endif
 SEND
 """
@@ -52,3 +59,16 @@ if NI>=19 and B[19]==0.0:
 endif
 SEND
 """
+
+ENDF_RECIPE_MF7_MT451 = """
+
+# Generalized Information File
+[MAT, 7, 451 / ZA, AWR, NA, 0, 0, 0]HEAD
+for i=1 to NA:
+    [MAT, 7, 451 / 0, 0, NAS, 0, 6*NI[i], NI[i]/ 
+          {ZAI[i,j], LISI[i,j], AFI[i,j], AWRI[i,j], SFI[i,j], 0}{j=1 to NI[i]} ] LIST
+endfor
+SEND
+"""
+
+


### PR DESCRIPTION
This pull request aims to address [two changes were introduced in the description of file 7 in  November 2023](https://www.nndc.bnl.gov/endfdocs/ENDF-102-2023.pdf#page=427):

- A new reaction, [MF7/MT451](https://www.nndc.bnl.gov/endfdocs/ENDF-102-2023.pdf#page=189), was included to add isotopic information on thermal scattering files. This reaction is called Generalized Information File.
- The thermal elastic reaction, MF7/MT2, was updated to include support for both coherent and incoherent contributions in the ["mixed elastic" format](https://www.nndc.bnl.gov/endfdocs/ENDF-102-2023.pdf#page=182).