### PR TITLE
Validate array_type option in EndfParserPy and EndfParserCpp

### DIFF
--- a/endf_parserpy/cpp_parsers/endf_parser_cpp.py
+++ b/endf_parserpy/cpp_parsers/endf_parser_cpp.py
@@ -3,7 +3,7 @@
 # Author(s):       Georg Schnabel
 # Email:           g.schnabel@iaea.org
 # Creation date:   2024/05/29
-# Last modified:   2026/05/17
+# Last modified:   2026/07/29
 # License:         MIT
 # Copyright (c) 2024-2026 International Atomic Energy Agency (IAEA)
 #
@@ -12,7 +12,11 @@
 import importlib
 import os
 from endf_parserpy.utils.accessories import EndfDict
-from ..endf_parser_base import EndfParserBase, _record_init_kwargs
+from ..endf_parser_base import (
+    EndfParserBase,
+    _record_init_kwargs,
+    _check_array_type,
+)
 
 
 class EndfParserCpp(EndfParserBase):
@@ -134,7 +138,10 @@ class EndfParserCpp(EndfParserBase):
         array_type : str
             The Python datatype to use for representing arrays read from
             ENDF-6 files. The two options are ``"dict"`` (default) and
-            ``"list"``.  *(parsing)*
+            ``"list"``. The value ``"list_slow"`` is also accepted and
+            equivalent to ``"list"``, for compatibility with the
+            :class:`~endf_parserpy.EndfParserPy` class. Any other value
+            raises a :class:`ValueError`. *(parsing)*
         skip_intzero: bool
             For numbers written out in decimal notation, eliminate
             the integer part if zero, e.g. `0.12` becomes `.12` to
@@ -157,6 +164,7 @@ class EndfParserCpp(EndfParserBase):
             structure. Off by default; only the Python parser performs
             this validation unconditionally. *(parsing, C++ only)*
         """
+        _check_array_type(array_type)
         self.read_opts = {
             "ignore_number_mismatch": ignore_number_mismatch,
             "ignore_zero_mismatch": ignore_zero_mismatch,

--- a/endf_parserpy/endf_parser_base.py
+++ b/endf_parserpy/endf_parser_base.py
@@ -3,7 +3,7 @@
 # Author(s):       Georg Schnabel
 # Email:           g.schnabel@iaea.org
 # Creation date:   2025/06/01
-# Last modified:   2026/05/17
+# Last modified:   2026/07/29
 # License:         MIT
 # Copyright (c) 2025-2026 International Atomic Energy Agency (IAEA)
 #
@@ -45,6 +45,20 @@ def _record_init_kwargs(init):
         return init(self, *args, **kwargs)
 
     return wrapper
+
+
+def _check_array_type(array_type):
+    """Reject unknown ``array_type`` values.
+
+    The Python and C++ parsers interpret unrecognized values in
+    opposite ways (falling back to dict and list mode, respectively),
+    so an invalid value must not pass silently.
+    """
+    valid_array_types = ("dict", "list", "list_slow")
+    if array_type not in valid_array_types:
+        raise ValueError(
+            f"invalid array_type `{array_type}`, " f"must be one of {valid_array_types}"
+        )
 
 
 MfNumberType = MtNumberType = int

--- a/endf_parserpy/interpreter/endf_parser.py
+++ b/endf_parserpy/interpreter/endf_parser.py
@@ -3,7 +3,7 @@
 # Author(s):       Georg Schnabel
 # Email:           g.schnabel@iaea.org
 # Creation date:   2022/05/30
-# Last modified:   2026/05/18
+# Last modified:   2026/07/29
 # License:         MIT
 # Copyright (c) 2022-2026 International Atomic Energy Agency (IAEA)
 #
@@ -89,7 +89,11 @@ from .endf_recipe_utils import (
 from endf_parserpy.endf_recipes import get_recipe_dict
 from endf_parserpy.utils.debugging_utils import TrackingDict
 from .helpers import array_dict_to_list
-from ..endf_parser_base import EndfParserBase, _record_init_kwargs
+from ..endf_parser_base import (
+    EndfParserBase,
+    _record_init_kwargs,
+    _check_array_type,
+)
 
 
 class EndfParserPy(EndfParserBase):
@@ -233,7 +237,10 @@ class EndfParserPy(EndfParserBase):
         array_type : str
             The Python datatype to use for representing arrays read from
             ENDF-6 files. The two options are ``"dict"`` (default) and
-            ``"list"``.  *(parsing)*
+            ``"list"``. The additional option ``"list_slow"`` yields the
+            same result as ``"list"`` via a slower implementation and
+            exists for debugging purposes. Any other value raises a
+            :class:`ValueError`. *(parsing)*
         explain_missing_variable : bool
             If the :func:`write` or :func:`writefile` method
             fail because a variable is missing in the dictionary,
@@ -267,6 +274,7 @@ class EndfParserPy(EndfParserBase):
             which will trigger warnings. Use `logging.ERROR` to suppress
             these warnings (you will need to `import logging`).
         """
+        _check_array_type(array_type)
         # obtain the parsing tree for the language
         # in which ENDF reading recipes are formulated
         if recipes is None:

--- a/tests/test_endf_cpp_parser_options.py
+++ b/tests/test_endf_cpp_parser_options.py
@@ -123,3 +123,17 @@ def test_list_mode_reading():
     endf_dict1 = parser_py.parsefile(endf_file)
     endf_dict2 = parser_cpp.parsefile(endf_file)
     compare_objects(endf_dict1, endf_dict2)
+
+
+def test_invalid_array_type_option_rejected():
+    with pytest.raises(ValueError, match="array_type"):
+        EndfParserCpp(array_type="invalid_option")
+
+
+def test_array_type_list_slow_equivalent_to_list():
+    parser_py = EndfParserPy(array_type="list_slow")
+    parser_cpp = EndfParserCpp(array_type="list_slow")
+    endf_file = Path(__file__).parent.joinpath("testdata", "n_2925_29-Cu-63.endf")
+    endf_dict1 = parser_py.parsefile(endf_file)
+    endf_dict2 = parser_cpp.parsefile(endf_file)
+    compare_objects(endf_dict1, endf_dict2)

--- a/tests/test_endf_parser_options.py
+++ b/tests/test_endf_parser_options.py
@@ -210,3 +210,8 @@ def test_array_type_list_and_list_slow_equivalent():
     endf_dict1 = parser1.parsefile(endf_file)
     endf_dict2 = parser2.parsefile(endf_file)
     compare_objects(endf_dict1, endf_dict2)
+
+
+def test_invalid_array_type_option_rejected():
+    with pytest.raises(ValueError, match="array_type"):
+        EndfParserPy(array_type="invalid_option")


### PR DESCRIPTION
## Summary

An unrecognized `array_type` value was silently interpreted in opposite ways by the two parser classes: `EndfParserPy` fell back to dict mode (list handling only triggers on the exact values `"list"`/`"list_slow"`), while the C++ parsers enable list mode for any value `!= "dict"` — for both reading and writing. A typo like `array_type="lists"` therefore produced structurally different output depending on which parser class was used, without any error.

- Add a shared `_check_array_type` helper in `endf_parser_base.py` and call it from both constructors, so values outside `("dict", "list", "list_slow")` raise a `ValueError`.
- Document that `"list_slow"` is accepted by `EndfParserCpp` (equivalent to `"list"`) and mention the new validation in both docstrings.

## Tests

- `test_invalid_array_type_option_rejected` in both `tests/test_endf_parser_options.py` and `tests/test_endf_cpp_parser_options.py`.
- `test_array_type_list_slow_equivalent_to_list` pinning `"list_slow"` equivalence between the Python and C++ parsers on a real ENDF file.
- Full run of the two option-test files: 32 passed.